### PR TITLE
Remove passing specs from menu

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+ruby:
+  config_file: .rubocop.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,232 @@
+AllCops:
+  Exclude:
+    - "vendor/**/*"
+    - "db/schema.rb"
+  UseCache: false
+Style/CollectionMethods:
+  Description: Preferred collection methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size
+  Enabled: true
+  PreferredMethods:
+    collect: map
+    collect!: map!
+    find_all: select
+    reduce: inject
+Style/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  Enabled: true
+  EnforcedStyle: trailing
+  SupportedStyles:
+  - leading
+  - trailing
+Style/FileName:
+  Description: Use snake_case for source file names.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
+  Enabled: false
+  Exclude: []
+Style/GuardClause:
+  Description: Check for conditionals that can be replaced with guard clauses
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
+  Enabled: false
+  MinBodyLength: 1
+Style/IfUnlessModifier:
+  Description: Favor modifier if/unless usage when you have a single-line body.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
+  Enabled: false
+  MaxLineLength: 80
+Style/OptionHash:
+  Description: Don't use option hashes when you can use keyword arguments.
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Description: Use `%`-literal delimiters consistently
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-literal-braces
+  Enabled: false
+  PreferredDelimiters:
+    "%": "()"
+    "%i": "()"
+    "%q": "()"
+    "%Q": "()"
+    "%r": "{}"
+    "%s": "()"
+    "%w": "()"
+    "%W": "()"
+    "%x": "()"
+Style/PredicateName:
+  Description: Check the names of predicate methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
+  Enabled: true
+  NamePrefix:
+  - is_
+  - has_
+  - have_
+  NamePrefixBlacklist:
+  - is_
+  Exclude:
+  - spec/**/*
+Style/RaiseArgs:
+  Description: Checks the arguments passed to raise/fail.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#exception-class-messages
+  Enabled: false
+  EnforcedStyle: exploded
+  SupportedStyles:
+  - compact
+  - exploded
+Style/SignalException:
+  Description: Checks for proper usage of fail and raise.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
+  Enabled: false
+  EnforcedStyle: semantic
+  SupportedStyles:
+  - only_raise
+  - only_fail
+  - semantic
+Style/SingleLineBlockParams:
+  Description: Enforces the names of some block params.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#reduce-blocks
+  Enabled: false
+  Methods:
+  - reduce:
+    - a
+    - e
+  - inject:
+    - a
+    - e
+Style/SingleLineMethods:
+  Description: Avoid single-line methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-single-line-methods
+  Enabled: false
+  AllowIfMethodIsEmpty: true
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
+  Enabled: true
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+Style/StringLiteralsInInterpolation:
+  Description: Checks if uses of quotes inside expressions in interpolated strings
+    match the configured preference.
+  Enabled: true
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+Style/TrailingComma:
+  Description: Checks for trailing comma in parameter lists and literals.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
+  Enabled: false
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - no_comma
+Metrics/AbcSize:
+  Description: A calculated magnitude based on number of assignments, branches, and
+    conditions.
+  Enabled: false
+  Max: 15
+Metrics/ClassLength:
+  Description: Avoid classes longer than 100 lines of code.
+  Enabled: false
+  CountComments: false
+  Max: 100
+Metrics/ModuleLength:
+  CountComments: false
+  Max: 100
+  Description: Avoid modules longer than 100 lines of code.
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Description: A complexity metric that is strongly correlated to the number of test
+    cases needed to validate a method.
+  Enabled: false
+  Max: 6
+Metrics/MethodLength:
+  Description: Avoid methods longer than 10 lines of code.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+  Enabled: false
+  CountComments: false
+  Max: 10
+Metrics/ParameterLists:
+  Description: Avoid parameter lists longer than three or four parameters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#too-many-params
+  Enabled: false
+  Max: 5
+  CountKeywordArgs: true
+Metrics/PerceivedComplexity:
+  Description: A complexity metric geared towards measuring complexity for a human
+    reader.
+  Enabled: false
+  Max: 7
+Lint/AssignmentInCondition:
+  Description: Don't use assignment in conditions.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
+  Enabled: false
+  AllowSafeAssignment: true
+Style/InlineComment:
+  Description: Avoid inline comments.
+  Enabled: false
+Style/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: false
+Style/Alias:
+  Description: Use alias_method instead of alias.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
+  Enabled: false
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: false
+Style/DoubleNegation:
+  Description: Checks for uses of double negation (!!).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-bang-bang
+  Enabled: false
+Style/EachWithObject:
+  Description: Prefer `each_with_object` over `inject` or `reduce`.
+  Enabled: false
+Style/EmptyLiteral:
+  Description: Prefer literals to Array.new/Hash.new/String.new.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#literal-array-hash
+  Enabled: false
+Style/ModuleFunction:
+  Description: Checks for usage of `extend self` in modules.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
+  Enabled: false
+Style/OneLineConditional:
+  Description: Favor the ternary operator(?:) over if/then/else/end constructs.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
+  Enabled: false
+Style/PerlBackrefs:
+  Description: Avoid Perl-style regex back references.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers
+  Enabled: false
+Style/Send:
+  Description: Prefer `Object#__send__` or `Object#public_send` to `send`, as `send`
+    may overlap with existing methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#prefer-public-send
+  Enabled: false
+Style/SpecialGlobalVars:
+  Description: Avoid Perl-style global variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms
+  Enabled: false
+Style/VariableInterpolation:
+  Description: Don't interpolate global, instance and class variables directly in
+    strings.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#curlies-interpolate
+  Enabled: false
+Style/WhenThen:
+  Description: Use when x then ... for one-line cases.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#one-line-cases
+  Enabled: false
+Lint/EachWithObjectArgument:
+  Description: Check for immutable argument given to each_with_object.
+  Enabled: true
+Lint/HandleExceptions:
+  Description: Don't suppress exception.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
+  Enabled: false
+Lint/LiteralInCondition:
+  Description: Checks of literals used in conditions.
+  Enabled: false
+Lint/LiteralInInterpolation:
+  Description: Checks for literals used in interpolation.
+  Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "failspell"
+require 'bundler/setup'
+require 'failspell'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-require "pry"
+require 'pry'
 Pry.start

--- a/failspell.gemspec
+++ b/failspell.gemspec
@@ -30,5 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'fakefs'
+  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'codeclimate-test-reporter'
 end

--- a/failspell.gemspec
+++ b/failspell.gemspec
@@ -4,20 +4,22 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'failspell/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "failspell"
+  spec.name          = 'failspell'
   spec.version       = Failspell::VERSION
-  spec.authors       = ["Dorian Karter"]
-  spec.email         = ["jobs@doriankarter.com"]
+  spec.authors       = ['Dorian Karter']
+  spec.email         = ['jobs@doriankarter.com']
 
-  spec.summary       = %q{A gem to help re-run failed specs in your suite}
-  spec.description   = %q{A gem to help re-run failed specs in your suite}
-  spec.homepage      = "https://github.com/dkarter/FailSpell"
-  spec.license       = "MIT"
+  spec.summary       = 'A gem to help re-run failed specs in your suite'
+  spec.description   = 'A gem to help re-run failed specs in your suite'
+  spec.homepage      = 'https://github.com/dkarter/FailSpell'
+  spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "bin"
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = 'bin'
   spec.executables   = ['fspell']
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
   spec.add_dependency 'colorize'
   spec.add_dependency 'thor'

--- a/lib/failspell.rb
+++ b/lib/failspell.rb
@@ -7,5 +7,3 @@ require 'failspell/cli'
 
 module FailSpell
 end
-
-

--- a/lib/failspell/cli.rb
+++ b/lib/failspell/cli.rb
@@ -18,16 +18,10 @@ module FailSpell
 
     desc 'rerun_failed [FILENAME]', 'Re-Runs Failed Specs (alias rf)'
     def rerun_failed(file = nil)
-      file ||= './tmp/failspell_last_run.json' # add .fspell
-
-      unless File.exists?(file)
-        puts "Cannot find result file: #{file}".red
-        exit
-      end
+      file = check_result_file(file)
 
       parser = FailSpell::RspecJsonParser.new(File.read(file))
       failed_specs = parser.parse
-
 
       FailSpell::SpecMenu.show.call(failed_specs) do |spec_path|
         puts "Re-Running rspec #{spec_path}".yellow
@@ -38,6 +32,17 @@ module FailSpell
         writer.save
       end
     end
+
+    private
+
+    def check_result_file(file = nil)
+      file ||= './tmp/failspell_last_run.json' # add .fspell
+
+      unless File.exist?(file)
+        puts "Cannot find result file: #{file}".red
+        exit
+      end
+      file
+    end
   end
 end
-

--- a/lib/failspell/rspec_json_writer.rb
+++ b/lib/failspell/rspec_json_writer.rb
@@ -1,0 +1,30 @@
+module FailSpell
+  class RspecJsonWriter
+
+    def initialize(file_path:)
+      @file_path = file_path
+      @results = JSON.parse(File.read(file_path))
+    end
+
+    def update_spec_status(full_spec_path:, success:)
+      spec_path_parts = full_spec_path.split(':')
+      spec_index = results['examples'].find_index do |spec|
+        spec['file_path'] == spec_path_parts[0] &&
+          spec['line_number'] == spec_path_parts[1].to_i
+      end
+
+      status = success ? 'passed' : 'failed'
+      results['examples'][spec_index]['status'] = status
+    end
+
+    def save
+      File.open(file_path, 'w') do |file|
+        file.write(results.to_json)
+      end
+    end
+
+    private
+    attr_reader :file_path, :results
+  end
+end
+

--- a/lib/failspell/rspec_json_writer.rb
+++ b/lib/failspell/rspec_json_writer.rb
@@ -1,6 +1,5 @@
 module FailSpell
   class RspecJsonWriter
-
     def initialize(file_path:)
       @file_path = file_path
       @results = JSON.parse(File.read(file_path))
@@ -10,7 +9,7 @@ module FailSpell
       spec_path_parts = full_spec_path.split(':')
       spec_index = results['examples'].find_index do |spec|
         spec['file_path'] == spec_path_parts[0] &&
-          spec['line_number'] == spec_path_parts[1].to_i
+        spec['line_number'] == spec_path_parts[1].to_i
       end
 
       status = success ? 'passed' : 'failed'
@@ -24,7 +23,7 @@ module FailSpell
     end
 
     private
+
     attr_reader :file_path, :results
   end
 end
-

--- a/lib/failspell/spec_menu.rb
+++ b/lib/failspell/spec_menu.rb
@@ -1,17 +1,19 @@
 module FailSpell
   class SpecMenu
     def self.show(failed_specs)
-      failed_specs.each_with_index do |spec, i|
-        say "(#{i+1}) #{spec['full_description']}"
-        say "    #{spec['file_path']}:#{spec['line_number']}".red
-      end
+      Proc.new do
+        failed_specs.each_with_index do |spec, i|
+          say "(#{i+1}) #{spec['full_description']}"
+          say "    #{spec['file_path']}:#{spec['line_number']}".red
+        end
 
-      prompt = "Which one would you like to re-run? (1-#{failed_specs.count}) "
-      rerun = ask(prompt, Integer) { |q| q.in = 1..failed_specs.count }
-      selected_spec = failed_specs[rerun - 1]
-      spec_path = "#{selected_spec['file_path']}:#{selected_spec['line_number']}"
-      yield(spec_path) if block_given?
-      spec_path
+        prompt = "Which one would you like to re-run? (1-#{failed_specs.count}) "
+        rerun = ask(prompt, Integer) { |q| q.in = 1..failed_specs.count }
+        selected_spec = failed_specs[rerun - 1]
+        spec_path = "#{selected_spec['file_path']}:#{selected_spec['line_number']}"
+        yield(spec_path) if block_given?
+        spec_path
+      end
     end
   end
 end

--- a/lib/failspell/spec_menu.rb
+++ b/lib/failspell/spec_menu.rb
@@ -1,16 +1,18 @@
 module FailSpell
   class SpecMenu
     def self.show(failed_specs)
-      Proc.new do
+      proc do
         failed_specs.each_with_index do |spec, i|
-          say "(#{i+1}) #{spec['full_description']}"
+          say "(#{i + 1}) #{spec['full_description']}"
           say "    #{spec['file_path']}:#{spec['line_number']}".red
         end
 
-        prompt = "Which one would you like to re-run? (1-#{failed_specs.count}) "
+        range = "1-#{failed_specs.count}"
+        prompt = "Which one would you like to re-run? (#{range}) "
         rerun = ask(prompt, Integer) { |q| q.in = 1..failed_specs.count }
         selected_spec = failed_specs[rerun - 1]
-        spec_path = "#{selected_spec['file_path']}:#{selected_spec['line_number']}"
+        spec_path =
+          "#{selected_spec['file_path']}:#{selected_spec['line_number']}"
         yield(spec_path) if block_given?
         spec_path
       end

--- a/lib/failspell/version.rb
+++ b/lib/failspell/version.rb
@@ -1,3 +1,3 @@
 module Failspell
-  VERSION = "0.1.1"
+  VERSION = '0.1.1'
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,9 +1,12 @@
 require 'spec_helper'
 
 describe FailSpell::CLI do
+  spec_runner = FailSpell::SpecRunner
+  spec_menu = FailSpell::SpecMenu
+
   context '#run_suite' do
     it 'calls spec runner' do
-      expect_any_instance_of(FailSpell::SpecRunner).to receive(:run_and_store_results)
+      expect_any_instance_of(spec_runner).to receive(:run_and_store_results)
       described_class.new.run_suite
     end
   end
@@ -16,20 +19,20 @@ describe FailSpell::CLI do
       full_failed_spec_path = "#{failed_test_path}:#{failed_test_line_number}"
       FileUtils.cp('./spec/fixtures/result.json', copy_file_path)
 
-      show_block = Proc.new do |failed_specs, &block|
+      show_block = proc do |_failed_specs, &block|
         block.call(full_failed_spec_path)
       end
 
-      allow(FailSpell::SpecMenu).to receive(:show).and_return(show_block)
+      allow(spec_menu).to receive(:show).and_return(show_block)
 
-      allow_any_instance_of(FailSpell::SpecRunner).to receive(:run).and_return(true)
+      allow_any_instance_of(spec_runner).to receive(:run).and_return(true)
 
       described_class.new.rerun_failed(copy_file_path)
 
       specs_json = JSON.parse(File.read(copy_file_path))['examples']
       newly_successful_spec = specs_json.find do |spec|
         spec['line_number'] == failed_test_line_number &&
-          spec['file_path'] == failed_test_path
+        spec['file_path'] == failed_test_path
       end
 
       expect(newly_successful_spec['status']).to eq('passed')

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -4,7 +4,35 @@ describe FailSpell::CLI do
   context '#run_suite' do
     it 'calls spec runner' do
       expect_any_instance_of(FailSpell::SpecRunner).to receive(:run_and_store_results)
-      FailSpell::CLI.new.run_suite
+      described_class.new.run_suite
+    end
+  end
+
+  context '#rerun_failed' do
+    it 'updated successful tests in json file' do
+      copy_file_path = '/tmp/test_rerun_failed_with_success.json'
+      failed_test_path = './spec/lib/relateiq/list_spec.rb'
+      failed_test_line_number = 78
+      full_failed_spec_path = "#{failed_test_path}:#{failed_test_line_number}"
+      FileUtils.cp('./spec/fixtures/result.json', copy_file_path)
+
+      show_block = Proc.new do |failed_specs, &block|
+        block.call(full_failed_spec_path)
+      end
+
+      allow(FailSpell::SpecMenu).to receive(:show).and_return(show_block)
+
+      allow_any_instance_of(FailSpell::SpecRunner).to receive(:run).and_return(true)
+
+      described_class.new.rerun_failed(copy_file_path)
+
+      specs_json = JSON.parse(File.read(copy_file_path))['examples']
+      newly_successful_spec = specs_json.find do |spec|
+        spec['line_number'] == failed_test_line_number &&
+          spec['file_path'] == failed_test_path
+      end
+
+      expect(newly_successful_spec['status']).to eq('passed')
     end
   end
 end

--- a/spec/emoji_formatter.rb
+++ b/spec/emoji_formatter.rb
@@ -1,17 +1,23 @@
 class EmojiFormatter < RSpec::Core::Formatters::ProgressFormatter
   # This registers the notifications this formatter supports, and tells
   # us that this was written against the RSpec 3.x formatter API.
-  RSpec::Core::Formatters.register self, :example_passed, :example_pending, :example_failed, :start_dump
+  RSpec::Core::Formatters.register(
+    self,
+    :example_passed,
+    :example_pending,
+    :example_failed,
+    :start_dump
+  )
 
   def example_passed(_notification)
-    output.print "💚 "
+    output.print '💚 '
   end
 
   def example_pending(_notification)
-    output.print "🙇 "
+    output.print '🙇 '
   end
 
   def example_failed(_notification)
-    output.print "💔 "
+    output.print '💔 '
   end
 end

--- a/spec/failspell/spec_runner_spec.rb
+++ b/spec/failspell/spec_runner_spec.rb
@@ -4,7 +4,8 @@ describe FailSpell::SpecRunner do
   context '#run' do
     it 'runs spec on system' do
       runner = described_class.new('some_path:123')
-      expect(runner).to receive(:system).with('rspec some_path:123') { 'success' }
+      command = 'rspec some_path:123'
+      expect(runner).to receive(:system).with(command) { 'success' }
       expect(runner.run).to eq('success')
     end
   end
@@ -17,5 +18,4 @@ describe FailSpell::SpecRunner do
       expect(runner.run_and_store_results).to eq('success')
     end
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-require "codeclimate-test-reporter"
+require 'codeclimate-test-reporter'
 CodeClimate::TestReporter.start
 require 'rspec'
 require 'fakefs/safe'


### PR DESCRIPTION
When a user runs a spec from the menu, if the spec passes it will be
removed from the list of failed specs

Test is passing but still a WIP!
Used as an interview/pair programming audition with a hashrocket candidate.

TODO:
1. Use FakeFS on tests that create files
2. Add a test for rspec json writer
3. Some refactoring to make the rerun method smaller and more focused (perhaps extract the method from the block passed to the menu.
